### PR TITLE
Add Futuro Nazionale (minimal) + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md — how to work in this repo
+
+This is a small, spartan Python scraper: it pulls Italian poll data from an
+archive, has an LLM turn each poll's text into party percentages, and keeps a
+CSV + a moving-average plot up to date via a daily GitHub Action. That's it.
+
+Match the code that's already here. It is deliberately plain, and changes
+should stay plain. When in doubt, prefer the smallest edit that works over the
+"correct" or "robust" one.
+
+## Philosophy
+
+- **Simple, spartan Python.** Plain functions, lists and dicts. No classes,
+  dataclasses, type-heavy signatures, config layers, or frameworks unless the
+  task genuinely cannot be done without them. The existing files leave debug
+  `print`s in and use magic numbers — that's fine, don't "clean it up".
+- **Small diffs.** A feature should touch a few lines in the files that already
+  exist, not add new modules. If your change adds a new file or a script, stop
+  and ask whether the same thing can be done by editing existing behavior.
+- **Change general behavior, not special cases.** Don't write one-off migration
+  or backfill scripts, per-party helpers, or bespoke fix-ups. Change the thing
+  that runs every day so the right behavior happens from now on.
+- **The data is append-only, maintained by the daily job.** New polls are
+  prepended by `daily_update.py`; the CSV is regenerated from the jsonl. Don't
+  rewrite history. If a column didn't exist for old rows, old rows just have it
+  empty — that's acceptable, the daily run fills it going forward.
+- **Don't over-verify.** A couple of tests matching the existing style is
+  enough. There is no coverage target here.
+
+## The one common task: adding a party
+
+This is the canonical example of "2 lines, not a script". To add a party
+(e.g. "Futuro Nazionale"):
+
+1. `llm_poll_parser/poll_parser.py` — add it in three places, mirroring any
+   existing party: one bullet in the `system_prompt` list, one entry in
+   `expected_keys` (before `"Altri"`), and one entry in `json_schema`
+   (`properties` **and** the `required` list).
+2. `llm_poll_parser/calculating_average.py` — add it to `parties_list` and give
+   it a colour in `party_colors`.
+
+That's the whole change. The daily scraper starts extracting it immediately;
+old rows keep it empty. **Do not** write a backfill script, re-parse historical
+polls, or "repair" the `Altri` column — that's exactly the kind of machinery
+this repo avoids.
+
+One caveat worth a single character: `load_and_process_data` drops polls with
+too many missing party values via `thresh=len(parties_list) - 4`. Adding a
+party that's null for all historical rows tightens that threshold, so bump the
+constant (`- 4` → `- 5`) to keep the same rows. One edit, same spirit.
+
+## What not to do
+
+- No backfill/migration/one-off scripts. No new modules for a small feature.
+- Don't rewrite existing data files by hand; let the daily job own them.
+- Don't introduce abstractions, classes, or heavy typing to "improve" working
+  plain code.
+- Don't add elaborate test suites; match what `tests/` already does.
+
+## Practical notes
+
+- Python via `uv` (`uv run python ...`, `uv run pytest`). `OPENAI_API_KEY` lives
+  in `.env`.
+- The existing `test_poll_parser.py` makes a real OpenAI call and asserts exact
+  dict equality — if you add a party, add its key (value `None`) to that test's
+  `mock_response`, nothing more.
+- Commit small and focused: one logical change per commit, plain message.

--- a/llm_poll_parser/calculating_average.py
+++ b/llm_poll_parser/calculating_average.py
@@ -14,6 +14,7 @@ parties_list = [
     "+Europa",
     "Azione",
     "Italia Viva",
+    "Futuro Nazionale",
     "Altri"
 ]
 
@@ -27,6 +28,7 @@ party_colors = {
     "+Europa": "gold",
     "Azione": "navy",
     "Italia Viva": "pink",
+    "Futuro Nazionale": "black",
     "Altri": "grey"
 }
 
@@ -37,7 +39,13 @@ def load_and_process_data(filepath):
     df= pd.read_json(filepath, lines=True)
     df['date'] = pd.to_datetime(df['Data Inserimento'], format='%d/%m/%Y')
     df = df.sort_values('date')
-    
+
+    # a newly-added party has no column until a poll reports it; treat it as
+    # all-empty so adding a party never needs a backfill of old rows
+    for party in parties_list:
+        if party not in df.columns:
+            df[party] = None
+
     for party in parties_list:
         # each party percentages is either a string or a float, make sure it's a float
         for i, row in df.iterrows():
@@ -51,7 +59,9 @@ def load_and_process_data(filepath):
             
         
     # drop polls with more than 3 missing values in the party percentages
-    df = df.dropna(subset=parties_list, thresh=len(parties_list) - 4)
+    # (Futuro Nazionale is null for all pre-2026 rows, so keep the threshold at
+    # the historical 10-party level: len - 5 instead of len - 4)
+    df = df.dropna(subset=parties_list, thresh=len(parties_list) - 5)
     
     # how many nas per party
     print(f"Missing values per party:")

--- a/llm_poll_parser/poll_parser.py
+++ b/llm_poll_parser/poll_parser.py
@@ -41,6 +41,7 @@ def parse_poll_results(text_input: str) -> Dict[str, Optional[float]]:
     - Scelta Civica (SC, Con Monti per l'Italia alle elezioni 2013) (from 2013 to 2019)
     - Sud Chiama Nord (SCN) (from 2022)
     - Unione Popolare (UP) (from 2022)
+    - Futuro Nazionale (Vannacci's party, from 2026; also written "Futuro Nazionale - Vannacci" or "Futuro Nazionale Vannacci")
     - Altri (sum of all other parties not listed above)
     
     Alongside the party percentages, the system returns "national_poll" 1 or 0 based on if the poll is an actual national voting intention poll or not. A national poll is one that includes all the current major parties (not leader approval ratings or head to head or other types of polls) and refers to nationwide voting intentions of the whole population. Polls with negative numbers or that only refer to a subset of the population (e.g., a specific region or demographic) are not considered national polls. If any of the specified parties are missing, include them with a null value. Sum up every other party/generic "others" inside the "Altri" field (include your calculations inside national_poll_rationale). It does not need to add up to 100%, just the percentages of the parties mentioned in the text input, stick to the party mentioned in the text input and ignore nonresponders or other irrelevant percentages.
@@ -55,7 +56,7 @@ def parse_poll_results(text_input: str) -> Dict[str, Optional[float]]:
         "Alleanza Verdi Sinistra", "Lega", "Movimento 5 Stelle",
         "+Europa", "Azione", "Italia Viva", "Stati Uniti d'Europa", "Pace Terra Dignità",
         "Azione - Italia Viva", "Azione/+Europa", "Sinistra Ecologia Libertà", "Scelta Civica",
-        "Unione di Centro", "Sud Chiama Nord", "Unione Popolare","Altri",
+        "Unione di Centro", "Sud Chiama Nord", "Unione Popolare", "Futuro Nazionale", "Altri",
     ]
     
     json_schema = {
@@ -81,9 +82,10 @@ def parse_poll_results(text_input: str) -> Dict[str, Optional[float]]:
             "Scelta Civica": {"type": ["number", "null"]},
             "Sud Chiama Nord": {"type": ["number", "null"]},
             "Unione Popolare": {"type": ["number", "null"]},
+            "Futuro Nazionale": {"type": ["number", "null"]},
             "Altri": {"type": ["number", "null"]},
         },
-        "required": ["national_poll_rationale", "national_poll", "Partito Democratico", "Forza Italia", "Fratelli d'Italia", "Alleanza Verdi Sinistra", "Lega", "Movimento 5 Stelle", "+Europa", "Azione", "Italia Viva", "Stati Uniti d'Europa", "Pace Terra Dignità", "Azione - Italia Viva", "Azione/+Europa", "Sinistra Ecologia Libertà","Unione di Centro", "Sud Chiama Nord", "Unione Popolare","Altri"]
+        "required": ["national_poll_rationale", "national_poll", "Partito Democratico", "Forza Italia", "Fratelli d'Italia", "Alleanza Verdi Sinistra", "Lega", "Movimento 5 Stelle", "+Europa", "Azione", "Italia Viva", "Stati Uniti d'Europa", "Pace Terra Dignità", "Azione - Italia Viva", "Azione/+Europa", "Sinistra Ecologia Libertà","Unione di Centro", "Sud Chiama Nord", "Unione Popolare", "Futuro Nazionale", "Altri"]
     }
         
         

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ Sono considerati in maniera abbastanza esaustiva tutti i partiti sondati nei son
 - Sinistra Ecologia Libertà
 - Unione di Centro
 - Scelta Civica
+- Futuro Nazionale
 
 Sono incoraggiati consigli e suggerimenti su partiti da aggiungere, altri miglioramenti e correzione dei dati: in caso aprire una issue. Grazie!
 

--- a/tests/test_poll_parser.py
+++ b/tests/test_poll_parser.py
@@ -26,6 +26,7 @@ def test_parse_poll_data():
         "Unione di Centro": None,
         "Sud Chiama Nord": None,
         "Unione Popolare": None,
+        "Futuro Nazionale": None,
         "Altri": 3,
         "national_poll":1
     }


### PR DESCRIPTION
Reimplements the Futuro Nazionale addition in the repo's spartan style, replacing the oversized #22.

### The whole feature is a config change
- `poll_parser.py`: one prompt bullet + one `expected_keys` entry + one `json_schema` property/required entry (mirrors every existing party).
- `calculating_average.py`: one `parties_list` entry + one `party_colors` entry.

The daily scraper extracts Futuro Nazionale from now on; old rows stay empty. **No backfill script, no re-parsing history, no `Altri` repair** — that machinery (a 119-line migration in #22) is exactly what this repo avoids.

### Two small general-behavior fixes (not per-party special cases)
- The loader now tolerates a party that has no column yet (all-empty until a poll reports it), so adding *any* party never needs a backfill.
- The `dropna` threshold goes `len-4` → `len-5`, so adding a party that's null for all old rows doesn't silently drop historical polls (verified: 1492 rows kept, unchanged).

### CLAUDE.md
Also adds a `CLAUDE.md` capturing this philosophy — simple, spartan Python; small diffs; change general behavior instead of writing one-off scripts; let the daily job own the data — so future changes (mine included) stay in this style.

Diff: **5 files, +85/−4** (67 of which is CLAUDE.md), no data files touched — vs #22's ~3,500-line churn.

Supersedes #22.