### PR TITLE
Aggiungo Futuro Nazionale

### DIFF
--- a/llm_poll_parser/calculating_average.py
+++ b/llm_poll_parser/calculating_average.py
@@ -14,6 +14,7 @@ parties_list = [
     "+Europa",
     "Azione",
     "Italia Viva",
+    "Futuro Nazionale",
     "Altri"
 ]
 
@@ -27,6 +28,7 @@ party_colors = {
     "+Europa": "gold",
     "Azione": "navy",
     "Italia Viva": "pink",
+    "Futuro Nazionale": "black",
     "Altri": "grey"
 }
 
@@ -37,7 +39,13 @@ def load_and_process_data(filepath):
     df= pd.read_json(filepath, lines=True)
     df['date'] = pd.to_datetime(df['Data Inserimento'], format='%d/%m/%Y')
     df = df.sort_values('date')
-    
+
+    # a newly-added party has no column until a poll reports it; treat it as
+    # all-empty so adding a party never needs a backfill of old rows
+    for party in parties_list:
+        if party not in df.columns:
+            df[party] = None
+
     for party in parties_list:
         # each party percentages is either a string or a float, make sure it's a float
         for i, row in df.iterrows():
@@ -51,7 +59,9 @@ def load_and_process_data(filepath):
             
         
     # drop polls with more than 3 missing values in the party percentages
-    df = df.dropna(subset=parties_list, thresh=len(parties_list) - 4)
+    # (Futuro Nazionale is null for all pre-2026 rows, so keep the threshold at
+    # the historical 10-party level: len - 5 instead of len - 4)
+    df = df.dropna(subset=parties_list, thresh=len(parties_list) - 5)
     
     # how many nas per party
     print(f"Missing values per party:")

--- a/llm_poll_parser/poll_parser.py
+++ b/llm_poll_parser/poll_parser.py
@@ -41,6 +41,7 @@ def parse_poll_results(text_input: str) -> Dict[str, Optional[float]]:
     - Scelta Civica (SC, Con Monti per l'Italia alle elezioni 2013) (from 2013 to 2019)
     - Sud Chiama Nord (SCN) (from 2022)
     - Unione Popolare (UP) (from 2022)
+    - Futuro Nazionale (Vannacci's party, from 2026; also written "Futuro Nazionale - Vannacci" or "Futuro Nazionale Vannacci")
     - Altri (sum of all other parties not listed above)
     
     Alongside the party percentages, the system returns "national_poll" 1 or 0 based on if the poll is an actual national voting intention poll or not. A national poll is one that includes all the current major parties (not leader approval ratings or head to head or other types of polls) and refers to nationwide voting intentions of the whole population. Polls with negative numbers or that only refer to a subset of the population (e.g., a specific region or demographic) are not considered national polls. If any of the specified parties are missing, include them with a null value. Sum up every other party/generic "others" inside the "Altri" field (include your calculations inside national_poll_rationale). It does not need to add up to 100%, just the percentages of the parties mentioned in the text input, stick to the party mentioned in the text input and ignore nonresponders or other irrelevant percentages.
@@ -55,7 +56,7 @@ def parse_poll_results(text_input: str) -> Dict[str, Optional[float]]:
         "Alleanza Verdi Sinistra", "Lega", "Movimento 5 Stelle",
         "+Europa", "Azione", "Italia Viva", "Stati Uniti d'Europa", "Pace Terra Dignità",
         "Azione - Italia Viva", "Azione/+Europa", "Sinistra Ecologia Libertà", "Scelta Civica",
-        "Unione di Centro", "Sud Chiama Nord", "Unione Popolare","Altri",
+        "Unione di Centro", "Sud Chiama Nord", "Unione Popolare", "Futuro Nazionale", "Altri",
     ]
     
     json_schema = {
@@ -81,9 +82,10 @@ def parse_poll_results(text_input: str) -> Dict[str, Optional[float]]:
             "Scelta Civica": {"type": ["number", "null"]},
             "Sud Chiama Nord": {"type": ["number", "null"]},
             "Unione Popolare": {"type": ["number", "null"]},
+            "Futuro Nazionale": {"type": ["number", "null"]},
             "Altri": {"type": ["number", "null"]},
         },
-        "required": ["national_poll_rationale", "national_poll", "Partito Democratico", "Forza Italia", "Fratelli d'Italia", "Alleanza Verdi Sinistra", "Lega", "Movimento 5 Stelle", "+Europa", "Azione", "Italia Viva", "Stati Uniti d'Europa", "Pace Terra Dignità", "Azione - Italia Viva", "Azione/+Europa", "Sinistra Ecologia Libertà","Unione di Centro", "Sud Chiama Nord", "Unione Popolare","Altri"]
+        "required": ["national_poll_rationale", "national_poll", "Partito Democratico", "Forza Italia", "Fratelli d'Italia", "Alleanza Verdi Sinistra", "Lega", "Movimento 5 Stelle", "+Europa", "Azione", "Italia Viva", "Stati Uniti d'Europa", "Pace Terra Dignità", "Azione - Italia Viva", "Azione/+Europa", "Sinistra Ecologia Libertà","Unione di Centro", "Sud Chiama Nord", "Unione Popolare", "Futuro Nazionale", "Altri"]
     }
         
         

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ Sono considerati in maniera abbastanza esaustiva tutti i partiti sondati nei son
 - Sinistra Ecologia Libertà
 - Unione di Centro
 - Scelta Civica
+- Futuro Nazionale
 
 Sono incoraggiati consigli e suggerimenti su partiti da aggiungere, altri miglioramenti e correzione dei dati: in caso aprire una issue. Grazie!
 

--- a/tests/test_poll_parser.py
+++ b/tests/test_poll_parser.py
@@ -26,6 +26,7 @@ def test_parse_poll_data():
         "Unione di Centro": None,
         "Sud Chiama Nord": None,
         "Unione Popolare": None,
+        "Futuro Nazionale": None,
         "Altri": 3,
         "national_poll":1
     }


### PR DESCRIPTION
Aggiungo Futuro Nazionale (il partito di Vannacci) ai partiti tracciati.

È in pratica solo config: lo metto nel prompt del parser (+ `expected_keys` e schema) e in `parties_list`/`party_colors`. Da adesso lo scraper lo estrae come gli altri, le righe vecchie restano vuote finché non ripasso lo storico (quello lo faccio a parte).

Ho dovuto sistemare due cose perché aggiungere un partito non rompesse niente:
- `load_and_process_data` ora regge un partito che nei dati non ha ancora la colonna (prima dava KeyError finché nessun sondaggio lo riportava)
- soglia del `dropna` da `len-4` a `len-5`: se no, aggiungendo un partito vuoto su tutto lo storico, buttavo via un po' di sondaggi vecchi dalla media. Così restano 1492 come prima.