### PR TITLE
Azione manuale per ri-parsare lo storico

### DIFF
--- a/.github/workflows/reparse.yaml
+++ b/.github/workflows/reparse.yaml
@@ -1,0 +1,51 @@
+name: Reparse historical polls (manual)
+on:
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Reparse polls from this date (DD/MM/YYYY). Leave empty to reparse all history."
+        required: false
+        default: ""
+
+jobs:
+  reparse_job:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Reparse stored poll text with the current parser
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: python llm_poll_parser/daily_update.py reparse "${{ github.event.inputs.since }}"
+
+    - name: Commit changes
+      run: |
+        git config --global user.name "GitHub Actions Bot"
+        git config --global user.email "actions@github.com"
+        git add .
+        if git diff-index --quiet HEAD; then
+          echo "No changes to commit"
+        else
+          git commit -m "Reparse historical polls: $(date +'%Y-%m-%d')"
+        fi
+      shell: bash
+
+    - name: Rebase and push changes
+      run: |
+        git fetch origin main
+        git rebase origin/main
+        git push origin main
+      shell: bash

--- a/llm_poll_parser/daily_update.py
+++ b/llm_poll_parser/daily_update.py
@@ -1,11 +1,13 @@
 import json
 import logging
 import time
+from datetime import datetime
 from typing import Union
 import pandas as pd
 from website_getter import get_poll_data, get_prossima_pagina, start_driver, find_sondaggi_table
 from archiving_polls import handle_one_pagina
 from calculating_average import load_and_process_data, make_temporal_plot, calculate_moving_average, parties_list, party_colors
+from poll_parser import parse_poll_results
 import pandas as pd
 
 def add_beginning_of_file(filename: str, poll_data: Union[dict, list[dict]]) -> None:
@@ -65,6 +67,31 @@ def convert_jsonl_to_csv():
     polls = pd.read_json("italian_polls.jsonl", lines=True)
     polls.to_csv("italian_polls.csv", index=False)
 
+def reparse(since=None):
+    # Re-run the parser over the raw text already stored for each poll, so
+    # parser/prompt changes (e.g. a newly added party) get applied to history
+    # without re-scraping the site. `since` is a DD/MM/YYYY floor; empty = all.
+    # This is what fixes a new party in old rows AND recomputes "Altri" for them.
+    filename = "italian_polls.jsonl"
+    logging.basicConfig(level=logging.INFO)
+    polls = [json.loads(line) for line in open(filename) if line.strip()]
+    since_date = datetime.strptime(since, "%d/%m/%Y") if since else None
+
+    for poll in polls:
+        if since_date and datetime.strptime(poll["Data Inserimento"], "%d/%m/%Y") < since_date:
+            continue
+        logging.info(f"Reparsing {poll['Data Inserimento']} - {poll['Titolo']}")
+        poll.update(parse_poll_results(poll["text"]))
+
+    with open(filename, "w") as file:
+        file.write("\n".join(json.dumps(poll) for poll in polls) + "\n")
+
+    polls = load_and_process_data(filename)
+    moving_averages = calculate_moving_average(polls)
+    update_readme_with_moving_averages(moving_averages)
+    make_temporal_plot(moving_averages, polls)
+    convert_jsonl_to_csv()
+
 def main():
     filename = "italian_polls.jsonl"
     logging.basicConfig(level=logging.INFO)
@@ -102,4 +129,8 @@ def main():
     logging.info("Quitted the driver")
 
 if __name__ == "__main__":
-    main()
+    import sys
+    if len(sys.argv) > 1 and sys.argv[1] == "reparse":
+        reparse(sys.argv[2] if len(sys.argv) > 2 else None)
+    else:
+        main()


### PR DESCRIPTION
Quando cambio il parser (tipo aggiungo un partito) le righe vecchie restano com'erano finché non le ripasso. Qui aggiungo il modo di farlo con un bottone, senza ri-scrapare il sito.

`reparse()` in `daily_update.py` rilancia `parse_poll_results` sul `text` grezzo già salvato di ogni sondaggio e riscrive i campi partito. Così:
- il nuovo partito (es. Futuro Nazionale) viene riempito anche nello storico
- "Altri" torna corretto da solo per quelle righe, perché lo rifà lo stesso parser che ora conosce il partito nuovo — niente sottrazioni a mano

C'è un input `since` (DD/MM/YYYY) per ripassare solo da una data in poi (es. solo l'era Futuro Nazionale) invece di tutto lo storico, così non spendo in chiamate LLM inutili.

L'azione (`reparse.yaml`) è `workflow_dispatch`, quindi la lancio a mano da GitHub quando serve. Non serve selenium, riusa la stessa macchineria di media/plot/csv del daily.

Va usata dopo aver mergiato #25 (Futuro Nazionale). Verificato che con un `since` futuro (nessuna riga toccata) il jsonl resta byte-identico, quindi ripassare solo un pezzo non sporca il resto.